### PR TITLE
Fix warning shown on some composer operations

### DIFF
--- a/src/assetbundles/citrus/CitrusAsset.php
+++ b/src/assetbundles/citrus/CitrusAsset.php
@@ -8,7 +8,7 @@
  * @copyright Copyright (c) 2018 Whitespace
  */
 
-namespace whitespace\citrus\assetbundles\Citrus;
+namespace whitespace\citrus\assetbundles\citrus;
 
 use Craft;
 use craft\web\AssetBundle;


### PR DESCRIPTION
e.g. on dump-autoload :
"Class whitespace\citrus\assetbundles\Citrus\CitrusAsset located in ./vendor/whitespace/citrus/src/assetbundles/citrus/CitrusAsset.php does not comply with psr-4 autoloading standard. Skipping."